### PR TITLE
Major redesign for 1.0.0.pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v1.0.0
+
+This is a release with major changes in the logic for selecting thumbs and
+refactoring to allow easier overriding of parts of the artwork logic in the
+application.
+
+Changes include:
+
+- When you're trying to select a retina thumb, the gem will try to select one
+  that is at least as wide or wider than the desired size and if there isn't
+  such a thumb the search will fallback to normal, non-retina thumbs.
+- Requesting a thumb style of '320x' will select sizes like '420x500', i.e.
+  sizes with height or a label only if there isn't a single thumb, larger than
+  the requested size and with no height and no label.
+- `artwork_thumb_for` has been renamed to `attachment_style_for`. Keep in mind
+  that now there's a different method named `artwork_thumb_for` which
+  selects only a compatible artwork thumb/style. Another new method, named
+  `plain_thumb_for` works for non-artwork compatible thumbs, e.g. `:foobar`.
+- The internal API has been changed to some extent due to refactoring and
+  changes.
+
 ## v0.7.3
 
 - Paperclip is no longer a dependency

--- a/lib/artwork.rb
+++ b/lib/artwork.rb
@@ -15,21 +15,24 @@ module Artwork
       File.dirname(__FILE__)
     end
 
-    def scale_in_current_resolution(size, base_resolution = nil)
+    def desired_thumb_for(size, base_resolution = nil)
       if size.is_a? Numeric
-        width = size
+        DesiredThumbnail.new(width: size, base_resolution: base_resolution)
       else
-        size, base = size.split('@')
+        thumb = DesiredThumbnail.from_style(size)
 
-        width = Thumbnail.from_style(size).width || 0
-        base_resolution ||= base
+        thumb.base_resolution = base_resolution if base_resolution
+
+        thumb
       end
+    end
 
-      base_resolution ||= Artwork.base_resolution
+    def scale_in_current_resolution(size, base_resolution = nil)
+      desired_thumb_for(size, base_resolution).width_in_current_resolution
+    end
 
-      resolution_ratio = base_resolution.to_f / Artwork.current_resolution.to_f
-
-      width.to_f / resolution_ratio
+    def expected_width_for(size, base_resolution = nil)
+      desired_thumb_for(size, base_resolution).expected_width
     end
   end
 end

--- a/lib/artwork.rb
+++ b/lib/artwork.rb
@@ -1,5 +1,7 @@
 require 'artwork/version'
 require 'artwork/configuration'
+require 'artwork/thumbnail'
+require 'artwork/desired_thumbnail'
 require 'artwork/model'
 require 'artwork/view'
 require 'artwork/controller'
@@ -8,7 +10,26 @@ require 'artwork/engine' if Object.const_defined?(:Rails) and Rails.const_define
 module Artwork
   extend Configuration
 
-  def self.root_path
-    File.dirname(__FILE__)
+  class << self
+    def root_path
+      File.dirname(__FILE__)
+    end
+
+    def scale_in_current_resolution(size, base_resolution = nil)
+      if size.is_a? Numeric
+        width = size
+      else
+        size, base = size.split('@')
+
+        width = Thumbnail.from_style(size).width || 0
+        base_resolution ||= base
+      end
+
+      base_resolution ||= Artwork.base_resolution
+
+      resolution_ratio = base_resolution.to_f / Artwork.current_resolution.to_f
+
+      width.to_f / resolution_ratio
+    end
   end
 end

--- a/lib/artwork/desired_thumbnail.rb
+++ b/lib/artwork/desired_thumbnail.rb
@@ -4,10 +4,20 @@ module Artwork
       def from_style(style)
         normal_style, base_resolution = style.to_s.split('@')
 
-        thumb = super(normal_style)
-        thumb.base_resolution = base_resolution
+        data = {}
 
-        thumb
+        if match = normal_style.match(Thumbnail::STYLE_PATTERN) and match[:retina_flag].nil?
+          data[:name]   = match[:name]
+          data[:width]  = match[:width].to_i
+          data[:height] = match[:height].to_i
+          data[:label]  = match[:label] ? match[:label].gsub(/^_|_$/, '') : nil
+        else
+          data[:name] = normal_style.to_s
+        end
+
+        data[:base_resolution] = base_resolution.to_i if base_resolution
+
+        new(data)
       end
 
       def compatible?(style)
@@ -16,25 +26,54 @@ module Artwork
     end
 
     def initialize(data = {})
-      super(data)
+      data = data.dup
 
-      @base_resolution = data[:base_resolution]
+      @base_resolution = data.delete(:base_resolution)
+
+      data[:name] = "#{data[:width]}x" if data[:name].nil? and data[:width]
+
+      super(data)
     end
 
-    attr_writer :base_resolution
+    def width=(value)
+      reset_cached_widths
+      super
+    end
 
     def base_resolution
       @base_resolution ||= Artwork.base_resolution
     end
 
-    def expected_width
-      result = Artwork.scale_in_current_resolution(width, base_resolution)
+    def base_resolution=(value)
+      reset_cached_widths
+      @base_resolution = value
+    end
 
-      if Artwork.load_2x_images?
-        result * 2
-      else
-        result
-      end
+    def retina?
+      Artwork.load_2x_images?
+    end
+
+    def width_in_current_resolution
+      return @width_in_current_resolution if @width_in_current_resolution
+
+      resolution_ratio = base_resolution.to_f / Artwork.current_resolution.to_f
+
+      @width_in_current_resolution = width.to_f / resolution_ratio
+    end
+
+    def expected_width
+      return @expected_width if @expected_width
+
+      result = width_in_current_resolution
+
+      @expected_width = retina? ? result * 2 : result
+    end
+
+    private
+
+    def reset_cached_widths
+      @expected_width = nil
+      @width_in_current_resolution = nil
     end
   end
 end

--- a/lib/artwork/desired_thumbnail.rb
+++ b/lib/artwork/desired_thumbnail.rb
@@ -1,0 +1,40 @@
+module Artwork
+  class DesiredThumbnail < Thumbnail
+    class << self
+      def from_style(style)
+        normal_style, base_resolution = style.to_s.split('@')
+
+        thumb = super(normal_style)
+        thumb.base_resolution = base_resolution
+
+        thumb
+      end
+
+      def compatible?(style)
+        from_style(style).compatible?
+      end
+    end
+
+    def initialize(data = {})
+      super(data)
+
+      @base_resolution = data[:base_resolution]
+    end
+
+    attr_writer :base_resolution
+
+    def base_resolution
+      @base_resolution ||= Artwork.base_resolution
+    end
+
+    def expected_width
+      result = Artwork.scale_in_current_resolution(width, base_resolution)
+
+      if Artwork.load_2x_images?
+        result * 2
+      else
+        result
+      end
+    end
+  end
+end

--- a/lib/artwork/model.rb
+++ b/lib/artwork/model.rb
@@ -74,7 +74,7 @@ module Artwork
       # If we did not find any matching attachment definitions,
       # the desired size is probably larger than all of our thumb widths,
       # So pick the largest one we have.
-      thumb || usable_thumbs.max_by { |current| current.width }
+      thumb || usable_thumbs.max_by(&:width)
     end
 
     def retina_artwork_thumb_for(attachment_name, thumbs, desired_thumb)
@@ -84,7 +84,7 @@ module Artwork
 
       thumb = retina_thumbs.find { |current| wanted_width <= current.width }
 
-      thumb || normal_artwork_thumb_for(attachment_name, thumbs, desired_thumb)
+      thumb || normal_artwork_thumb_for(attachment_name, thumbs, desired_thumb) || retina_thumbs.max_by(&:width)
     end
 
     private

--- a/lib/artwork/model.rb
+++ b/lib/artwork/model.rb
@@ -1,60 +1,90 @@
-require 'artwork/thumbnail'
-
 module Artwork
   module Model
-    def artwork_thumb_for(attachment_name, size, alternative_sizes = nil)
-      size = determine_alternative_size_for(alternative_sizes) || size
-
-      size, base_resolution = size.to_s.split('@')
-      base_resolution ||= Artwork.base_resolution
-
-      desired_thumb = Thumbnail.new(size)
-      matching_thumb_name = nil
-
-      ratio_for_current_resolution = base_resolution.to_f / Artwork.current_resolution.to_f
-
-      if desired_thumb.compatible?
-        desired_size = desired_thumb.width / ratio_for_current_resolution
-
-        thumbs = attachment_styles_for(attachment_name).map { |thumb_name| Thumbnail.new(thumb_name) }
-
-        thumbs = thumbs \
-          .select(&:compatible?) \
-          .reject(&:retina?) \
-          .select { |thumb| desired_thumb.label.nil? or desired_thumb.label == thumb.label.to_s } \
-          .select { |thumb| desired_thumb.aspect_ratio.nil? or desired_thumb.same_aspect_ratio_with?(thumb) } \
-          .sort
-
-        thumbs.each do |thumb|
-          if desired_size <= thumb.width
-            matching_thumb_name = thumb.name
-            break
-          end
-        end
-
-        # If we did not find any matching attachment definitions,
-        # the desired size is probably larger than all of our thumb widths,
-        # So pick the last (largest) one we have.
-        return nil if thumbs.empty?
-        matching_thumb_name ||= thumbs.last.name
-      end
-
-      matching_thumb_name ||= size.to_sym
-
-      if Artwork.load_2x_images? and attachment_styles_for(attachment_name).include?(:"#{matching_thumb_name}_2x")
-        matching_thumb_name = :"#{matching_thumb_name}_2x"
-      end
-
-      matching_thumb_name.to_sym
-    end
-
     def artwork_url(attachment_name, size, options = {})
-      thumb_name = artwork_thumb_for(attachment_name, size, options)
+      thumb_name = attachment_style_for(attachment_name, size, options)
+
+      return nil unless thumb_name
+
       send(attachment_name).url(thumb_name, options)
     end
 
     def attachment_styles_for(attachment_name)
       self.class.attachment_definitions[attachment_name.to_sym][:styles].keys
+    end
+
+    def attachment_style_for(attachment_name, size, alternative_sizes = nil)
+      size = determine_alternative_size_for(alternative_sizes) || size
+
+      result =
+        if DesiredThumbnail.compatible?(size)
+          artwork_thumb_for(attachment_name, size)
+        else
+          plain_thumb_for(attachment_name, size)
+        end
+
+      return nil unless result
+
+      if result.respond_to?(:name)
+        result.name.to_sym
+      else
+        result.to_sym
+      end
+    end
+
+    def artwork_thumbs_for(attachment_name)
+      attachment_styles_for(attachment_name).map { |style| Thumbnail.from_style(style) }
+    end
+
+    def artwork_thumb_for(attachment_name, size)
+      desired_thumb = DesiredThumbnail.from_style(size)
+
+      thumbs = artwork_thumbs_for(attachment_name)
+
+      thumbs = thumbs.select { |thumb| desired_thumb.is_like?(thumb) }.sort
+
+      if Artwork.load_2x_images?
+        artwork_retina_thumb_for(attachment_name, thumbs, desired_thumb)
+      else
+        artwork_normal_thumb_for(attachment_name, thumbs, desired_thumb)
+      end
+    end
+
+    def plain_thumb_for(attachment_name, label)
+      all_styles = attachment_styles_for(attachment_name)
+
+      normal_thumb = label.to_sym
+      retina_thumb = :"#{label}_2x"
+
+      if Artwork.load_2x_images? and all_styles.include?(retina_thumb)
+        retina_thumb
+      elsif all_styles.include?(normal_thumb)
+        normal_thumb
+      end
+    end
+
+    def artwork_normal_thumb_for(attachment_name, thumbs, desired_thumb)
+      wanted_width = desired_thumb.expected_width
+
+      usable_thumbs = thumbs.select(&:compatible?).reject(&:retina?)
+
+      return nil if usable_thumbs.empty?
+
+      thumb = usable_thumbs.find { |current| wanted_width <= current.width }
+
+      # If we did not find any matching attachment definitions,
+      # the desired size is probably larger than all of our thumb widths,
+      # So pick the largest one we have.
+      thumb || usable_thumbs.max_by { |current| current.width }
+    end
+
+    def artwork_retina_thumb_for(attachment_name, thumbs, desired_thumb)
+      wanted_width = desired_thumb.expected_width
+
+      retina_thumbs = thumbs.select(&:compatible?).select(&:retina?)
+
+      thumb = retina_thumbs.find { |current| wanted_width <= current.width }
+
+      thumb || artwork_normal_thumb_for(attachment_name, thumbs, desired_thumb)
     end
 
     private

--- a/lib/artwork/model.rb
+++ b/lib/artwork/model.rb
@@ -15,19 +15,19 @@ module Artwork
     def attachment_style_for(attachment_name, size, alternative_sizes = nil)
       size = determine_alternative_size_for(alternative_sizes) || size
 
-      result =
+      thumb =
         if DesiredThumbnail.compatible?(size)
           artwork_thumb_for(attachment_name, size)
         else
           plain_thumb_for(attachment_name, size)
         end
 
-      return nil unless result
+      return nil unless thumb
 
-      if result.respond_to?(:name)
-        result.name.to_sym
+      if thumb.respond_to?(:name)
+        thumb.name.to_sym
       else
-        result.to_sym
+        thumb.to_sym
       end
     end
 

--- a/lib/artwork/model.rb
+++ b/lib/artwork/model.rb
@@ -43,9 +43,9 @@ module Artwork
       thumbs = thumbs.select { |thumb| desired_thumb.is_like?(thumb) }.sort
 
       if Artwork.load_2x_images?
-        artwork_retina_thumb_for(attachment_name, thumbs, desired_thumb)
+        retina_artwork_thumb_for(attachment_name, thumbs, desired_thumb)
       else
-        artwork_normal_thumb_for(attachment_name, thumbs, desired_thumb)
+        normal_artwork_thumb_for(attachment_name, thumbs, desired_thumb)
       end
     end
 
@@ -62,7 +62,7 @@ module Artwork
       end
     end
 
-    def artwork_normal_thumb_for(attachment_name, thumbs, desired_thumb)
+    def normal_artwork_thumb_for(attachment_name, thumbs, desired_thumb)
       wanted_width = desired_thumb.expected_width
 
       usable_thumbs = thumbs.select(&:compatible?).reject(&:retina?)
@@ -77,14 +77,14 @@ module Artwork
       thumb || usable_thumbs.max_by { |current| current.width }
     end
 
-    def artwork_retina_thumb_for(attachment_name, thumbs, desired_thumb)
+    def retina_artwork_thumb_for(attachment_name, thumbs, desired_thumb)
       wanted_width = desired_thumb.expected_width
 
       retina_thumbs = thumbs.select(&:compatible?).select(&:retina?)
 
       thumb = retina_thumbs.find { |current| wanted_width <= current.width }
 
-      thumb || artwork_normal_thumb_for(attachment_name, thumbs, desired_thumb)
+      thumb || normal_artwork_thumb_for(attachment_name, thumbs, desired_thumb)
     end
 
     private

--- a/lib/artwork/version.rb
+++ b/lib/artwork/version.rb
@@ -1,3 +1,3 @@
 module Artwork
-  VERSION = '1.0.0.pre'
+  VERSION = '1.0.0'
 end

--- a/lib/artwork/version.rb
+++ b/lib/artwork/version.rb
@@ -1,3 +1,3 @@
 module Artwork
-  VERSION = '0.7.3'
+  VERSION = '1.0.0.pre'
 end

--- a/spec/artwork/thumbnail_spec.rb
+++ b/spec/artwork/thumbnail_spec.rb
@@ -5,23 +5,23 @@ module Artwork
     expected_defaults = {:compatible? => true}
 
     examples = {
-      :'320x'               => {:width => 320,  :height => nil, :retina? => false, :label => nil},
-      :'320x_2x'            => {:width => 320,  :height => nil, :retina? => true,  :label => nil},
-      :'640x_2x'            => {:width => 640,  :height => nil, :retina? => true,  :label => nil},
-      :'640x'               => {:width => 640,  :height => nil, :retina? => false, :label => nil},
-      :'1280x'              => {:width => 1280, :height => nil, :retina? => false, :label => nil},
-      :'1280x_2x'           => {:width => 1280, :height => nil, :retina? => true,  :label => nil},
-      :'2000x'              => {:width => 2000, :height => nil, :retina? => false, :label => nil},
-      :'1500x_2x'           => {:width => 1500, :height => nil, :retina? => true,  :label => nil},
-      :'320x_some_label'    => {:width => 320,  :height => nil, :retina? => false, :label => 'some_label'},
-      :'320x_some_label_2x' => {:width => 320,  :height => nil, :retina? => true,  :label => 'some_label'},
-      :'320x500'            => {:width => 320,  :height => 500, :retina? => false, :label => nil},
-      :'320x500_2x'         => {:width => 320,  :height => 500, :retina? => true,  :label => nil},
-      :'320x500_crop'       => {:width => 320,  :height => 500, :retina? => false, :label => 'crop'},
-      :'320x500_crop_2x'    => {:width => 320,  :height => 500, :retina? => true,  :label => 'crop'},
-      :'320x_'              => {:width => 320,  :height => nil, :retina? => false, :label => ''},
-      :'320x500_'           => {:width => 320,  :height => 500, :retina? => false, :label => ''},
-      :'320x500__2x'        => {:width => 320,  :height => 500, :retina? => true,  :label => ''},
+      :'320x'               => {:width => 320,  :height => nil,  :retina? => false, :label => nil},
+      :'320x_2x'            => {:width => 640,  :height => nil,  :retina? => true,  :label => nil},
+      :'640x_2x'            => {:width => 1280, :height => nil,  :retina? => true,  :label => nil},
+      :'640x'               => {:width => 640,  :height => nil,  :retina? => false, :label => nil},
+      :'1280x'              => {:width => 1280, :height => nil,  :retina? => false, :label => nil},
+      :'1280x_2x'           => {:width => 2560, :height => nil,  :retina? => true,  :label => nil},
+      :'2000x'              => {:width => 2000, :height => nil,  :retina? => false, :label => nil},
+      :'1500x_2x'           => {:width => 3000, :height => nil,  :retina? => true,  :label => nil},
+      :'320x_some_label'    => {:width => 320,  :height => nil,  :retina? => false, :label => 'some_label'},
+      :'320x_some_label_2x' => {:width => 640,  :height => nil,  :retina? => true,  :label => 'some_label'},
+      :'320x500'            => {:width => 320,  :height => 500,  :retina? => false, :label => nil},
+      :'320x500_2x'         => {:width => 640,  :height => 1000, :retina? => true,  :label => nil},
+      :'320x500_crop'       => {:width => 320,  :height => 500,  :retina? => false, :label => 'crop'},
+      :'320x500_crop_2x'    => {:width => 640,  :height => 1000, :retina? => true,  :label => 'crop'},
+      :'320x_'              => {:width => 320,  :height => nil,  :retina? => false, :label => ''},
+      :'320x500_'           => {:width => 320,  :height => 500,  :retina? => false, :label => ''},
+      :'320x500__2x'        => {:width => 640,  :height => 1000, :retina? => true,  :label => ''},
       :unsupported          => {:compatible? => false},
       'unsupported_thumb'   => {:compatible? => false},
     }
@@ -30,7 +30,7 @@ module Artwork
       expected_properties = expected_defaults.merge(expected_properties)
       expected_properties.each do |field_name, expected_value|
         it "##{field_name} is #{expected_value.inspect} for #{thumb_name}" do
-          thumbnail = Thumbnail.new(thumb_name)
+          thumbnail = Thumbnail.from_style(thumb_name)
           expect(thumbnail.send(field_name)).to eq expected_value
         end
       end
@@ -43,62 +43,62 @@ module Artwork
 
     describe '#eq' do
       it 'is true for different objects with the same width, height, label and retina flag' do
-        expect(Thumbnail.new(:'1200x500_crop_2x')).to eq Thumbnail.new('1200x500_crop_2x')
-        expect(Thumbnail.new(:'1200x_2x')).to eq Thumbnail.new('1200x_2x')
-        expect(Thumbnail.new(:'1200x')).to eq Thumbnail.new('1200x')
-        expect(Thumbnail.new(:'1200x_black_and_white')).to eq Thumbnail.new('1200x_black_and_white')
+        expect(Thumbnail.from_style(:'1200x500_crop_2x')).to eq Thumbnail.from_style('1200x500_crop_2x')
+        expect(Thumbnail.from_style(:'1200x_2x')).to eq Thumbnail.from_style('1200x_2x')
+        expect(Thumbnail.from_style(:'1200x')).to eq Thumbnail.from_style('1200x')
+        expect(Thumbnail.from_style(:'1200x_black_and_white')).to eq Thumbnail.from_style('1200x_black_and_white')
       end
 
       it 'is false for different objects if any of the width, height, label or retina flag differ' do
-        expect(Thumbnail.new(:'1200x500_crop_2x')).not_to eq Thumbnail.new('1200x500_crop')
-        expect(Thumbnail.new(:'1200x500_crop_2x')).not_to eq Thumbnail.new('1200x500crop_2x')
-        expect(Thumbnail.new(:'1200x500_crop_2x')).not_to eq Thumbnail.new('1201x500_crop_2x')
-        expect(Thumbnail.new(:'1200x500_crop_2x')).not_to eq Thumbnail.new('1500x')
-        expect(Thumbnail.new(:'1200x500_crop_2x')).not_to eq Thumbnail.new('1200x400_crop_2x')
+        expect(Thumbnail.from_style(:'1200x500_crop_2x')).not_to eq Thumbnail.from_style('1200x500_crop')
+        expect(Thumbnail.from_style(:'1200x500_crop_2x')).not_to eq Thumbnail.from_style('1200x500crop_2x')
+        expect(Thumbnail.from_style(:'1200x500_crop_2x')).not_to eq Thumbnail.from_style('1201x500_crop_2x')
+        expect(Thumbnail.from_style(:'1200x500_crop_2x')).not_to eq Thumbnail.from_style('1500x')
+        expect(Thumbnail.from_style(:'1200x500_crop_2x')).not_to eq Thumbnail.from_style('1200x400_crop_2x')
       end
     end
 
     describe '#aspect_ratio' do
       it 'is nil if height is not present or is zero' do
-        expect(Thumbnail.new('400x_label_2x').aspect_ratio).to be_nil
-        expect(Thumbnail.new('400x_2x').aspect_ratio).to be_nil
-        expect(Thumbnail.new('400x_').aspect_ratio).to be_nil
-        expect(Thumbnail.new('400x').aspect_ratio).to be_nil
-        expect(Thumbnail.new('400x0').aspect_ratio).to be_nil
+        expect(Thumbnail.from_style('400x_label_2x').aspect_ratio).to be_nil
+        expect(Thumbnail.from_style('400x_2x').aspect_ratio).to be_nil
+        expect(Thumbnail.from_style('400x_').aspect_ratio).to be_nil
+        expect(Thumbnail.from_style('400x').aspect_ratio).to be_nil
+        expect(Thumbnail.from_style('400x0').aspect_ratio).to be_nil
       end
 
       it 'is calculated as a decimal when both a width and a height are present' do
-        expect(Thumbnail.new('400x300').aspect_ratio).to be_within(0.1).of(1.33)
-        expect(Thumbnail.new('1600x900').aspect_ratio).to be_within(0.1).of(1.78)
-        expect(Thumbnail.new('1600x900_with_label').aspect_ratio).to be_within(0.1).of(1.78)
-        expect(Thumbnail.new('1600x900_with_label_2x').aspect_ratio).to be_within(0.1).of(1.78)
+        expect(Thumbnail.from_style('400x300').aspect_ratio).to be_within(0.1).of(1.33)
+        expect(Thumbnail.from_style('1600x900').aspect_ratio).to be_within(0.1).of(1.78)
+        expect(Thumbnail.from_style('1600x900_with_label').aspect_ratio).to be_within(0.1).of(1.78)
+        expect(Thumbnail.from_style('1600x900_with_label_2x').aspect_ratio).to be_within(0.1).of(1.78)
       end
     end
 
     describe '#same_aspect_ratio_with?' do
       it 'returns nil if either thumbs have no clear height' do
-        expect(Thumbnail.new('400x300').same_aspect_ratio_with?(Thumbnail.new('400x'))).to be_nil
-        expect(Thumbnail.new('400x0').same_aspect_ratio_with?(Thumbnail.new('400x300'))).to be_nil
+        expect(Thumbnail.from_style('400x300').same_aspect_ratio_with?(Thumbnail.from_style('400x'))).to be_nil
+        expect(Thumbnail.from_style('400x0').same_aspect_ratio_with?(Thumbnail.from_style('400x300'))).to be_nil
       end
 
       it 'returns true if thumbs have aspect ratios within 0.1 of one another' do
-        expect(Thumbnail.new('400x300').same_aspect_ratio_with?(Thumbnail.new('400x300'))).to be true
-        expect(Thumbnail.new('400x300').same_aspect_ratio_with?(Thumbnail.new('1600x1200_with_label_2x'))).to be true
-        expect(Thumbnail.new('400x300').same_aspect_ratio_with?(Thumbnail.new('400x301'))).to be true
+        expect(Thumbnail.from_style('400x300').same_aspect_ratio_with?(Thumbnail.from_style('400x300'))).to be true
+        expect(Thumbnail.from_style('400x300').same_aspect_ratio_with?(Thumbnail.from_style('1600x1200_with_label_2x'))).to be true
+        expect(Thumbnail.from_style('400x300').same_aspect_ratio_with?(Thumbnail.from_style('400x301'))).to be true
       end
 
       it 'returns false if thumbs have different aspect ratios not within 0.1 of one another' do
-        expect(Thumbnail.new('400x300').same_aspect_ratio_with?(Thumbnail.new('400x200'))).to be false
-        expect(Thumbnail.new('400x300').same_aspect_ratio_with?(Thumbnail.new('5x10'))).to be false
+        expect(Thumbnail.from_style('400x300').same_aspect_ratio_with?(Thumbnail.from_style('400x200'))).to be false
+        expect(Thumbnail.from_style('400x300').same_aspect_ratio_with?(Thumbnail.from_style('5x10'))).to be false
       end
     end
 
     describe 'comparison' do
       it 'is based on the thumb width' do
-        small  = Thumbnail.new('90x_crop')
-        medium = Thumbnail.new('500x_crop')
-        large  = Thumbnail.new('1090x_2x')
-        huge   = Thumbnail.new('3200x')
+        small  = Thumbnail.from_style('90x_crop')
+        medium = Thumbnail.from_style('500x_crop')
+        large  = Thumbnail.from_style('1090x_2x')
+        huge   = Thumbnail.from_style('3200x')
 
         unsorted = [huge, large, small, medium]
 

--- a/spec/artwork_spec.rb
+++ b/spec/artwork_spec.rb
@@ -15,4 +15,89 @@ describe Artwork do
     expect(Artwork).to respond_to(:load_2x_images?)
     expect(Artwork).to respond_to(:current_resolution)
   end
+
+  describe 'proxy methods to DesiredThumbnail' do
+    before :each do
+      Artwork.base_resolution    = 1000
+      Artwork.current_resolution = 1000
+      Artwork.actual_resolution  = 1000
+      Artwork.load_2x_images     = false
+    end
+
+    describe '::scale_in_current_resolution' do
+      it 'will scale the passed width in the current resolution' do
+        expect(Artwork.scale_in_current_resolution(320)).to eq(320)
+        expect(Artwork.scale_in_current_resolution(320, 500)).to eq(640)
+        expect(Artwork.scale_in_current_resolution('280x')).to eq(280)
+        expect(Artwork.scale_in_current_resolution('280x_crop')).to eq(280)
+        expect(Artwork.scale_in_current_resolution('280x500_crop')).to eq(280)
+        expect(Artwork.scale_in_current_resolution('320x@500')).to eq(640)
+        expect(Artwork.scale_in_current_resolution('320x@500', 250)).to eq(1280)
+
+        Artwork.current_resolution = 2000
+        expect(Artwork.scale_in_current_resolution(320)).to eq(640)
+        expect(Artwork.scale_in_current_resolution(320, 500)).to eq(1280)
+        expect(Artwork.scale_in_current_resolution('280x')).to eq(560)
+        expect(Artwork.scale_in_current_resolution('280x_crop')).to eq(560)
+        expect(Artwork.scale_in_current_resolution('280x500_crop')).to eq(560)
+        expect(Artwork.scale_in_current_resolution('320x@500')).to eq(1280)
+        expect(Artwork.scale_in_current_resolution('320x@500', 250)).to eq(2560)
+      end
+
+      it 'is not affected by the retina flag' do
+        Artwork.load_2x_images     = true
+
+        expect(Artwork.scale_in_current_resolution(320)).to eq(320)
+        expect(Artwork.scale_in_current_resolution(320, 500)).to eq(640)
+        expect(Artwork.scale_in_current_resolution('280x')).to eq(280)
+        expect(Artwork.scale_in_current_resolution('280x_crop')).to eq(280)
+        expect(Artwork.scale_in_current_resolution('280x500_crop')).to eq(280)
+        expect(Artwork.scale_in_current_resolution('320x@500')).to eq(640)
+        expect(Artwork.scale_in_current_resolution('320x@500', 250)).to eq(1280)
+
+        Artwork.current_resolution = 2000
+        expect(Artwork.scale_in_current_resolution(320)).to eq(640)
+        expect(Artwork.scale_in_current_resolution(320, 500)).to eq(1280)
+        expect(Artwork.scale_in_current_resolution('280x')).to eq(560)
+        expect(Artwork.scale_in_current_resolution('280x_crop')).to eq(560)
+        expect(Artwork.scale_in_current_resolution('280x500_crop')).to eq(560)
+        expect(Artwork.scale_in_current_resolution('320x@500')).to eq(1280)
+        expect(Artwork.scale_in_current_resolution('320x@500', 250)).to eq(2560)
+      end
+    end
+
+    # The same as ::scale_in_current_resolution but it will double the width if retina
+    describe '::expected_width_for' do
+      it 'will return the expedted width in the current resolution' do
+        expect(Artwork.expected_width_for(320)).to eq(320)
+        expect(Artwork.expected_width_for(320, 500)).to eq(640)
+        expect(Artwork.expected_width_for('280x')).to eq(280)
+        expect(Artwork.expected_width_for('280x_crop')).to eq(280)
+        expect(Artwork.expected_width_for('280x500_crop')).to eq(280)
+        expect(Artwork.expected_width_for('320x@500')).to eq(640)
+        expect(Artwork.expected_width_for('320x@500', 250)).to eq(1280)
+
+        Artwork.current_resolution = 2000
+        expect(Artwork.expected_width_for(320)).to eq(640)
+        expect(Artwork.expected_width_for(320, 500)).to eq(1280)
+        expect(Artwork.expected_width_for('280x')).to eq(560)
+        expect(Artwork.expected_width_for('280x_crop')).to eq(560)
+        expect(Artwork.expected_width_for('280x500_crop')).to eq(560)
+        expect(Artwork.expected_width_for('320x@500')).to eq(1280)
+        expect(Artwork.expected_width_for('320x@500', 250)).to eq(2560)
+      end
+
+      it 'will double the width if retina is expected' do
+        Artwork.load_2x_images     = true
+
+        expect(Artwork.expected_width_for(320)).to eq(640)
+        expect(Artwork.expected_width_for(320, 500)).to eq(1280)
+        expect(Artwork.expected_width_for('280x')).to eq(560)
+        expect(Artwork.expected_width_for('280x_crop')).to eq(560)
+        expect(Artwork.expected_width_for('280x500_crop')).to eq(560)
+        expect(Artwork.expected_width_for('320x@500')).to eq(1280)
+        expect(Artwork.expected_width_for('320x@500', 250)).to eq(2560)
+      end
+    end
+  end
 end

--- a/spec/shared/model.rb
+++ b/spec/shared/model.rb
@@ -58,8 +58,8 @@ RSpec.shared_examples 'an artwork model' do
 
   describe '#artwork_url' do
     describe 'behaviour' do
-      it 'returns the computed url of an attachment by delegating to artwork_thumb_for' do
-        expect(instance).to receive(:artwork_thumb_for).with(:photo, :size, 'options').and_return(:computed_size)
+      it 'returns the computed url of an attachment by delegating to attachment_style_for' do
+        expect(instance).to receive(:attachment_style_for).with(:photo, :size, 'options').and_return(:computed_size)
 
         attachment = double
         expect(attachment).to receive(:url).with(:computed_size, 'options').and_return 'some/url'
@@ -69,7 +69,7 @@ RSpec.shared_examples 'an artwork model' do
       end
 
       it 'works with two arguments and a hash options' do
-        expect(instance).to receive(:artwork_thumb_for).with(:photo, :size, :some => 'options').and_return(:computed_size)
+        expect(instance).to receive(:attachment_style_for).with(:photo, :size, :some => 'options').and_return(:computed_size)
 
         attachment = double
         expect(attachment).to receive(:url).with(:computed_size, :some => 'options').and_return 'some/url'
@@ -79,7 +79,7 @@ RSpec.shared_examples 'an artwork model' do
       end
 
       it 'works with two arguments only without any options hash' do
-        expect(instance).to receive(:artwork_thumb_for).with(:photo, :size, {}).and_return(:computed_size)
+        expect(instance).to receive(:attachment_style_for).with(:photo, :size, {}).and_return(:computed_size)
 
         attachment = double
         expect(attachment).to receive(:url).with(:computed_size, {}).and_return 'some/url'
@@ -107,7 +107,7 @@ RSpec.shared_examples 'an artwork model' do
     end
   end
 
-  describe '#artwork_thumb_for' do
+  describe '#attachment_style_for' do
     before :each do
       Artwork.base_resolution    = 1000
       Artwork.current_resolution = 1000
@@ -116,7 +116,7 @@ RSpec.shared_examples 'an artwork model' do
     end
 
     def expect_thumb(size, expected)
-      expect(instance.artwork_thumb_for(attachment_name, *Array(size))).to eq expected
+      expect(instance.attachment_style_for(attachment_name, *Array(size))).to eq expected
     end
 
     it 'picks the exact requested size if it exists' do
@@ -154,7 +154,7 @@ RSpec.shared_examples 'an artwork model' do
     it 'passes through unsupported thumb names' do
       expect_thumb 'unsupported', :unsupported
 
-      Artwork.load_2x_images     = true
+      Artwork.load_2x_images = true
       Artwork.base_resolution = 1000
       Artwork.current_resolution = 5000
 
@@ -162,7 +162,7 @@ RSpec.shared_examples 'an artwork model' do
     end
 
     it 'picks the nearest non-retina size to our desizred size' do
-      expect_thumb '390x', :'400x500'
+      expect_thumb '390x', :'640x'
       expect_thumb '420x', :'640x'
     end
 
@@ -202,16 +202,16 @@ RSpec.shared_examples 'an artwork model' do
       expect_thumb '319x498_crop', :'320x500_crop'
     end
 
-    it 'returns the largest thumb with the requested label if no other suitable sizes are found' do
+    it 'returns the largest nonretina thumb with the requested label if no other suitable sizes are found' do
       expect_thumb '20000x_crop', :'320x500_crop'
       Artwork.load_2x_images = true
-      expect_thumb '20000x_crop', :'320x500_crop_2x'
+      expect_thumb '20000x_crop', :'320x500_crop'
     end
 
-    it 'returns the largest thumb with the requested aspect ratio if no other suitable sizes are found' do
+    it 'returns the largest nonretina thumb with the requested aspect ratio if no other suitable sizes are found' do
       expect_thumb '8000x10000', :'400x500'
       Artwork.load_2x_images = true
-      expect_thumb '8000x10000', :'400x500_2x'
+      expect_thumb '8000x10000', :'400x500'
     end
 
     it 'returns nil if no thumbnail matches the requested aspect ratio' do

--- a/spec/shared/model.rb
+++ b/spec/shared/model.rb
@@ -222,6 +222,17 @@ RSpec.shared_examples 'an artwork model' do
       expect_thumb '319x_nonexistant_label', nil
     end
 
+    it 'will return the exact thumb for retina thumbs' do
+      expect_thumb '320x_2x', :'320x_2x'
+      expect_thumb '310x_2x', nil
+
+      Artwork.current_resolution = 1111
+      expect_thumb '320x_2x', :'320x_2x'
+
+      Artwork.load_2x_images = true
+      expect_thumb '320x_2x', :'320x_2x'
+    end
+
     context 'with an alternative sizes definition' do
       it 'ignores alternative sizes if current resolution is above all the max resolutions given' do
         Artwork.current_resolution = 1000


### PR DESCRIPTION
Changes in the logic for selecting thumbs:
- when trying to select a retina thumb it will try to select one that
  is >= to the wanted size and if there isn't such will fallback to
  normal thumbs
- things like '320x' will select sizes like '420x500' only if the
  isn't anything like '640x' aka larger than '320x'

Adds more places in which you could change the logic of how to select a
thumb, e.g. you could overwrite artwork_thumbs_for so that it return
thumbs with width and height that you have save for example in a db.

Rename artwork_thumb_for -> attachment_style_for
NB. there is still an artwork_thumb_for method that selects only a compatible artwork thumb/style
The attachment_style_for is combination of artwork_thumb_for and plain_thumb_for.
The second handles noncompatible styles.
